### PR TITLE
AdQuality SDK

### DIFF
--- a/extension-ironsource/ext.properties
+++ b/extension-ironsource/ext.properties
@@ -1,6 +1,6 @@
 [iron_source]
 
-version.default = 1.0.0
+version.default = 1.1.0
 adcolony_android.type = string
 
 admob_android.private = 1

--- a/extension-ironsource/manifests/android/build.gradle
+++ b/extension-ironsource/manifests/android/build.gradle
@@ -35,6 +35,7 @@ repositories {
 }
 dependencies {
  implementation 'com.ironsource.sdk:mediationsdk:7.7.0' 
+ implementation 'com.ironsource:adqualitysdk:7.20.0'
 
 // Remove for AMAZON:
 // --- NOT AMAZON START ---

--- a/extension-ironsource/src/ironsource_ios.mm
+++ b/extension-ironsource/src/ironsource_ios.mm
@@ -238,6 +238,7 @@ void Initialize_Ext(const char* version, const char* extVersion) {
 }
 
 void Init(const char* appKey) {
+    [[IronSourceAdQuality getInstance] initializeWithAppKey:appKey];
     [IronSource initWithAppKey:[NSString stringWithUTF8String:appKey] delegate:ironSourceExtInitAdDelegate];
 }
 

--- a/extension-ironsource/src/java/com/defold/ironsource/IronSourceJNI.java
+++ b/extension-ironsource/src/java/com/defold/ironsource/IronSourceJNI.java
@@ -18,6 +18,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
 
+import com.ironsource.adqualitysdk.sdk.IronSourceAdQuality;
 import com.ironsource.mediationsdk.IronSource;
 import com.ironsource.mediationsdk.integration.IntegrationHelper;
 import com.ironsource.mediationsdk.sdk.LevelPlayRewardedVideoListener;
@@ -66,6 +67,7 @@ public class IronSourceJNI {
     }
 
     public void init(String appKey) {
+        IronSourceAdQuality.getInstance().initialize(activity, appKey);
         IronSource.setLevelPlayRewardedVideoListener(new DefoldLevelPlayRewardedVideoListener());
         IronSource.setLevelPlayInterstitialListener(new DefoldLevelPlayInterstitialListener());
         //TODO: add AD Units android.app.Activity, java.lang.String, com.ironsource.mediationsdk.sdk.InitializationListener, com.ironsource.mediationsdk.IronSource$AD_UNIT...


### PR DESCRIPTION
The extension now supports the [IronSource Ad Quality SDK](https://www.is.com/adquality/) which can be used review which ads that are served to your users and report problematic content, ad network quality issues and measure how your ads perform.

The Ad Quality SDK will be initialized together with the IronSource SDK when calling `ironsource.init()`.

Fixes #20 